### PR TITLE
Injectable void extension

### DIFF
--- a/Sources/Voiper/Injectable.swift
+++ b/Sources/Voiper/Injectable.swift
@@ -9,3 +9,9 @@ public protocol Injectable {
     associatedtype Configuration
     init(configuration: Configuration)
 }
+
+extension Injectable where Configuration == Void {
+    init() {
+        self.init(configuration: ())
+    }
+}

--- a/Sources/Voiper/Injectable.swift
+++ b/Sources/Voiper/Injectable.swift
@@ -1,0 +1,11 @@
+//
+//  Injectable.swift
+//  
+//
+//  Created by Mayur Deshmukh on 2020-07-27.
+//
+
+public protocol Injectable {
+    associatedtype Configuration
+    init(configuration: Configuration)
+}

--- a/Sources/Voiper/VOIPER.swift
+++ b/Sources/Voiper/VOIPER.swift
@@ -1,10 +1,5 @@
 import UIKit
 
-public protocol Injectable {
-    associatedtype Configuration
-    init(configuration: Configuration)
-}
-
 public protocol StoryboardInstantiable: UIViewController {
     static var storyboardName: String { get }
     static var viewControllerName: String { get }


### PR DESCRIPTION
### What
This PR aims to add an extension for `Injectable` when the `Configuration` is `Void`. This would enable users to initialise the injectables with the new convenient empty initialiser.