### PR TITLE
Adding the option to create module without storyboard

### DIFF
--- a/Sources/Voiper/VOIPER.swift
+++ b/Sources/Voiper/VOIPER.swift
@@ -17,8 +17,23 @@ public extension StoryboardInstantiable {
     }
 }
 
+public enum ViewControllerInitMethod {
+    case storyboard
+    case code
+}
+
+public protocol ViewControllerInitProtocol: class {
+    static var initMethod: ViewControllerInitMethod { get }
+}
+
+extension ViewControllerInitProtocol {
+    public static var initMethod: ViewControllerInitMethod {
+        return .storyboard
+    }
+}
+
 public protocol Organiser {
-    associatedtype ViewController: ViewControllerProtocol & StoryboardInstantiable
+    associatedtype ViewController: ViewControllerProtocol & StoryboardInstantiable & ViewControllerInitProtocol
     associatedtype Interactor: InteractorProtocol & Injectable
     associatedtype Presenter: PresenterProtocol & Injectable
     associatedtype Router: RouterProtocol & Injectable
@@ -32,7 +47,7 @@ extension Organiser {
     }
     
     private static func wireUpModule(presenter: Presenter, interactor: Interactor, router: Router) -> ViewController {
-        let viewController = ViewController.instantiateFromStoryboard()
+        let viewController = ViewController.initMethod == .storyboard ? ViewController.instantiateFromStoryboard() : ViewController()
         presenter.set(viewDelegate: viewController)
         presenter.set(router: router)
         presenter.set(interactor: interactor)

--- a/Sources/Voiper/ViewController.swift
+++ b/Sources/Voiper/ViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public typealias TableViewController = TableViewControllerClass & ViewControllerType & StoryboardInstantiable
+public typealias TableViewController = TableViewControllerClass & ViewControllerType & StoryboardInstantiable & ViewControllerInitProtocol
 open class TableViewControllerClass: UITableViewController, ViewControllerProtocol {
     public var _presenter: PresenterProtocol?
     
@@ -9,7 +9,7 @@ open class TableViewControllerClass: UITableViewController, ViewControllerProtoc
     }
 }
 
-public typealias ViewController = ViewControllerClass & ViewControllerType & StoryboardInstantiable
+public typealias ViewController = ViewControllerClass & ViewControllerType & StoryboardInstantiable & ViewControllerInitProtocol
 open class ViewControllerClass: UIViewController, ViewControllerProtocol {
     public var _presenter: PresenterProtocol?
     


### PR DESCRIPTION
This will add the support of creating modules without the storyboard.

It could be improved further with adding the storyboard and view controller name as associated values on the enum.
