### PR TITLE
Introduce Instantiable: Decouple StoryboardInstantiable and make it optional

### DIFF
--- a/Sources/Voiper/VOIPER.swift
+++ b/Sources/Voiper/VOIPER.swift
@@ -1,6 +1,10 @@
 import UIKit
 
-public protocol StoryboardInstantiable: UIViewController {
+public protocol Instantiable {
+    static func instantiate()
+}
+
+public protocol StoryboardInstantiable: UIViewController, Instantiable {
     static var storyboardName: String { get }
     static var viewControllerName: String { get }
     static func instantiateFromStoryboard() -> Self
@@ -14,6 +18,10 @@ public extension StoryboardInstantiable {
     }
     static var viewControllerName: String {
         String(describing: Self.self)
+    }
+    
+    public static func instantiate() {
+        return instantiateFromStoryboard()
     }
 }
 

--- a/Sources/Voiper/VOIPER.swift
+++ b/Sources/Voiper/VOIPER.swift
@@ -1,10 +1,16 @@
 import UIKit
 
-public protocol Instantiable {
-    static func instantiate()
+public protocol Instantiable: UIViewController {
+    static func instantiate() -> Self
 }
 
-public protocol StoryboardInstantiable: UIViewController, Instantiable {
+public extension Instantiable {
+    static func instantiate() -> Self {
+        return Self.init()
+    }
+}
+
+public protocol StoryboardInstantiable: Instantiable {
     static var storyboardName: String { get }
     static var viewControllerName: String { get }
     static func instantiateFromStoryboard() -> Self
@@ -20,13 +26,13 @@ public extension StoryboardInstantiable {
         String(describing: Self.self)
     }
     
-    public static func instantiate() {
+    static func instantiate() -> Self {
         return instantiateFromStoryboard()
     }
 }
 
 public protocol Organiser {
-    associatedtype ViewController: ViewControllerProtocol & StoryboardInstantiable
+    associatedtype ViewController: ViewControllerProtocol & Instantiable
     associatedtype Interactor: InteractorProtocol & Injectable
     associatedtype Presenter: PresenterProtocol & Injectable
     associatedtype Router: RouterProtocol & Injectable
@@ -40,7 +46,7 @@ extension Organiser {
     }
     
     private static func wireUpModule(presenter: Presenter, interactor: Interactor, router: Router) -> ViewController {
-        let viewController = ViewController.instantiateFromStoryboard()
+        let viewController = ViewController.instantiate()
         presenter.set(viewDelegate: viewController)
         presenter.set(router: router)
         presenter.set(interactor: interactor)

--- a/Sources/Voiper/ViewController.swift
+++ b/Sources/Voiper/ViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public typealias TableViewController = TableViewControllerClass & ViewControllerType & StoryboardInstantiable
+public typealias TableViewController = TableViewControllerClass & ViewControllerType & Instantiable
 open class TableViewControllerClass: UITableViewController, ViewControllerProtocol {
     public var _presenter: PresenterProtocol?
     
@@ -9,7 +9,7 @@ open class TableViewControllerClass: UITableViewController, ViewControllerProtoc
     }
 }
 
-public typealias ViewController = ViewControllerClass & ViewControllerType & StoryboardInstantiable
+public typealias ViewController = ViewControllerClass & ViewControllerType & Instantiable
 open class ViewControllerClass: UIViewController, ViewControllerProtocol {
     public var _presenter: PresenterProtocol?
     


### PR DESCRIPTION
This PR aims to introduce `Instantiable`, which will be used in wiring up Voiper modules. `StoryboardInstantiable` now extends from `Instantiable` and satisfies it internally. `Instantiable` has a default definition too.